### PR TITLE
fix issue in subnet import, if gateway is not defined

### DIFF
--- a/lib/smart_proxy_dhcp_bluecat/bluecat_api.rb
+++ b/lib/smart_proxy_dhcp_bluecat/bluecat_api.rb
@@ -231,6 +231,12 @@ module Proxy
             properties = parse_properties(result['properties'])
             net = IPAddress.parse(properties['CIDR'])
             opts = { routers: [properties['gateway']] }
+
+            if properties['gateway'].nil?
+              logger.error("subnet issue: " + properties['CIDR'] + " skipped, due missing gateway in bluecat")
+              next
+            end
+
             ::Proxy::DHCP::Subnet.new(net.address, net.netmask, opts)
           end
           subnets.compact


### PR DESCRIPTION
we had a subnet in bluecat were the gateway address was defined as a normal address instead of a gateway address. the subnet list function ran into an issue with that. 

in future we log an error message and skip networks without a gateway